### PR TITLE
Fix typos and html tag errors

### DIFF
--- a/public_NOTUSED/education.html
+++ b/public_NOTUSED/education.html
@@ -82,14 +82,14 @@
     </nav>
 
     <body>
-      <h1 style="padding: 100px; padding-bottom: 50px; font-size: 5vw; color: ##ffcc00; text-align: center;"> Educational Resources <span style="color: white;"></h1>
+      <h1 style="padding: 100px; padding-bottom: 50px; font-size: 5vw; color: #ffcc00; text-align: center;"> Educational Resources <span style="color: white;"></h1>
       <div class="container-fluid">
         <div class="row">
           <div class="col-lg-4 col-sm-12" style="padding-bottom: 25px;">
             <div class="card" style="background-color: transparent;">
               <div class="card-body" style="background-color: #2B2E32; border-radius: 15px; height: inherit;">
                 <h5 class="card-title" style="color: #FFFFFF; font-size: 30px;">Reading Materials</h5>
-                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; text-size: 12px;" href="https://www.washingtonpost.com/blogs/post-partisan/wp/2016/01/16/white-privilege-explained/">What Is White Privelige?</a></p>
+                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; text-size: 12px;" href="https://www.washingtonpost.com/blogs/post-partisan/wp/2016/01/16/white-privilege-explained/">What Is White Privilege?</a></p>
 
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.benjerry.com/home/whats-new/2016/systemic-racism-is-real">What Is Systemic Racism?</a>
                   7 ways we know systemic racism is real.</p>
@@ -109,7 +109,7 @@
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.amazon.com/gp/product/1568585985/ref=ox_sc_saved_title_3?smid=ATVPDKIKX0DER&psc=1">Stamped from the Beginning: The Definitive History of
                     Racist Ideas in America:</a>
                   By Ibram X. Kendi</p>
-                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.sentencingproject.org/publications/un-report-on-racial-disparities/">Racial Risparities in the U.S Criminal Justice System"</a>
+                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.sentencingproject.org/publications/un-report-on-racial-disparities/">Racial Disparities in the U.S Criminal Justice System"</a>
                   The United States operates two distinct criminal justice systems: one for wealthy people and another for people of color. </p>
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.urban.org/features/structural-racism-america">Structural Racism In America:</a>
                   This source examines how historical and ongoing public policies, institutional practices, and cultural narratives perpetuate racial inequalities and constrain mobility for communities of color. </p>
@@ -124,7 +124,7 @@
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://drive.google.com/file/d/1gl9JejcGcVW-xBvoLyk1wCH4xbbXYFy6/view">On Being White... And Other Lies:</a>
                   By James Baldwin.</p>
 
-                < </div>
+                </div>
               </div>
             </div>
             <div class="col-lg-4 col-sm-12" style="padding-bottom: 25px;">
@@ -149,9 +149,7 @@
                     </a> Project South is a Southern-based leadership development organization that creates spaces for movement building. They have been working with communities to strengthen leadership and to provide popular political and economic
                     education for personal and social transformation.</p>
                   <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.reclaimtheblock.org/home"> Reclaim the Block:
-                    </a> Reclaim the Block organizes Minneapolis community and city council members to move money from the police department into other areas of the citys budget that truly promote community health and safety.</p>
-                  <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.reclaimtheblock.org/home"> Society for the Study of Social Problems:
-                    </a> he SSSP's stated purpose is to promote and protect sociological research and teaching on significant problems of social life. </p>
+                    </a> Reclaim the Block organizes Minneapolis community and city council members to move money from the police department into other areas of the city's budget that truly promote community health and safety.</p>
                   <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.reclaimtheblock.org/home"> Society for the Study of Social Problems:
                     </a> The SSSP's stated purpose is to promote and protect sociological research and teaching on significant problems of social life. </p>
                   <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://100blackmen.org/"> 100 Black Men:
@@ -160,36 +158,36 @@
               </div>
             </div>
             <div class="col-lg-4 col-sm-12">
-              <div class="card" style="background-color: transparent;" style="padding-bottom: 25px;">
+              <div class="card" style="background-color: transparent; padding-bottom: 25px;">
                 <div class="card-body" style="background-color: #2B2E32; border-radius: 15px; height: inherit;">
                   <h5 class="card-title" style="color: #FFFFFF; font-size: 30px;">Quick Facts</h5>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px;">
                     <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.aclu.org/issues/racial-justice/race-and-economic-justice> Inequality In Education </a></p>
 
-                    <p class="card-text"><span style="color: ##ffcc00;">Black students are suspended and expelled from school three times more often than white students are.</span></p>
+                    <p class="card-text"><span style="color: #ffcc00;">Black students are suspended and expelled from school three times more often than white students are.</span></p>
 
 
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height: inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality /> Race and Econonmic Inequality</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality > Race and Economic Inequality</a></p>
 
                     <p class="card-text"><span style="color: white;">The median wealth of white households is 20 times that of black households and 18 times that of Latino households.</span></p>
                     <br>
                     <p class="card-text"><span style="color: white;">In the US, Black individuals are twice as likely to be unemployed than white individuals. Once employed, Black individuals earn nearly 25% less than their white counterparts. <a
-                          style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality /> (Economic Policy Institute)</a></span></p>
+                          style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality > (Economic Policy Institute)</a></span></p>
 
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height: inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.ahrq.gov/sites/default/files/wysiwyg/research/findings/nhqrdr/2018qdr-final.pdf. />Healthcare Inequality</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.ahrq.gov/sites/default/files/wysiwyg/research/findings/nhqrdr/2018qdr-final.pdf. >Healthcare Inequality</a></p>
 
                     <p class="card-text"><span style="color: white;"> From 2013 to 2017, white patients in the US received better quality health care than about 34% of Hispanic patients, 40% of Black patients, and 40% of Native American
                         patients (National Healthcare Quality and Disparities Report, 2020)</span></p>
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height: inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.sentencingproject.org/publications/un-report-on-racial-disparities/ /> Criminal Justice Inequality </a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.sentencingproject.org/publications/un-report-on-racial-disparities/ > Criminal Justice Inequality </a></p>
 
                     <p class="card-text"><span style="color: white;"> African-American adults are 5.9 times as likely to be incarcerated than whitess (US Bureau of Justice Statistics, 2018).</span></p>
                     <br>
@@ -201,11 +199,11 @@
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height:inherit;">
                     <p class="card-text"><span style="color: white;"> After being fired for misconduct, 450 out of 1,800 officers were able to get their jobs back. </span></p>
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://theweek.com/articles/860002/unjust-power-police-unions />Mathis, Joel (2019, August).</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://theweek.com/articles/860002/unjust-power-police-unions >Mathis, Joel (2019, August).</a></p>
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height:inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://supreme.justia.com/cases/federal/us/457/800/case.html />Qualified Immunity</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://supreme.justia.com/cases/federal/us/457/800/case.html >Qualified Immunity</a></p>
 
                     <p class="card-text"><span style="color: white;"> An officer cannot be held civilly liable for violating a person's rights unless the person's right is established "beyond dispute," and the officer violates a clearly established
                         law that a "reasonable" officer should know. </span></p>
@@ -232,6 +230,7 @@
           <!-- Initialize Firebase -->
           <script src="/__/firebase/init.js"></script>
           <script src="/js/script.js"></script>
+      </div>
     </body>
 
     </html>

--- a/public_NOTUSED/education.html
+++ b/public_NOTUSED/education.html
@@ -189,7 +189,7 @@
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height: inherit;">
                     <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.sentencingproject.org/publications/un-report-on-racial-disparities/ > Criminal Justice Inequality </a></p>
 
-                    <p class="card-text"><span style="color: white;"> African-American adults are 5.9 times as likely to be incarcerated than whitess (US Bureau of Justice Statistics, 2018).</span></p>
+                    <p class="card-text"><span style="color: white;"> African-American adults are 5.9 times as likely to be incarcerated than whites (US Bureau of Justice Statistics, 2018).</span></p>
                     <br>
                     <p class="card-text"><span style="color: white;">
                         <p class="card-text"><span style="color: white;"> Black Americans are more likely than white Americans to be arrested. Once arrested, they are more likely to be convicted, and once convicted, they are more likely to experience

--- a/public_NOTUSED/index.html
+++ b/public_NOTUSED/index.html
@@ -66,7 +66,7 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-lg-8" style="padding-top: 100px;">
-        <div class="card" style="background-color: transparent;" style="padding-bottom: 25px;">
+        <div class="card" style="background-color: transparent; padding-bottom: 25px;">
           <div class="card-body" style="background-color: #2B2E32; border-radius: 15px;">
             <h5 class="card-title" style="color: #ffcc00; font-size: 30px; text-align: center;">Find Your State</h5>
             <div class="container-fluid">

--- a/public_NOTUSED/petitions.html
+++ b/public_NOTUSED/petitions.html
@@ -218,7 +218,7 @@
 </nav>
 
 <body>
-  <h1 style="padding: 100px; padding-bottom: 50px; font-size: 5vw; color: ##ffcc00; text-align: center;"> Take Action From Home <span style="color: white;"></h1>
+  <h1 style="padding: 100px; padding-bottom: 50px; font-size: 5vw; color: #ffcc00; text-align: center;"> Take Action From Home <span style="color: white;"></h1>
   <div class="container-fluid">
     <div class="row">
       <div class="col-lg-4 col-sm-12" style="padding-bottom: 25px;">
@@ -311,11 +311,11 @@
           </div>
         </div>
         <div class="col-lg-4 col-sm-12">
-          <div class="card" style="background-color: transparent;" style="padding-bottom: 25px;">
+          <div class="card" style="background-color: transparent; padding-bottom: 25px;">
             <div class="card-body" style="background-color: #2B2E32; border-radius: 15px; height: inherit;">
               <h5 class="card-title" style="color: #FFFFFF; font-size: 30px;">Numbers to Call</h5>
               <div style="background-color: #212529; border-radius: 15px; padding: 15px;">
-                <p class="card-text"><span style="color: ##ffcc00;">Contact:</span></p>
+                <p class="card-text"><span style="color: #ffcc00;">Contact:</span></p>
                 <p class="card-text">Contact each of the below numbers and pressure officials to hold law enforcement accountable for their actions. Information taken from <a style="color: #ffcc00; text-decoration: underline; "
                     href=https://twitter.com/ambivaIcnt> #blacklivesmatter</a></p>
 

--- a/public_NOTUSED/safety.html
+++ b/public_NOTUSED/safety.html
@@ -116,7 +116,7 @@
         </div>
       </div>
       <div class="col-lg-4 col-sm-12">
-        <div class="card" style="background-color: transparent;" style="padding-bottom: 25px;">
+        <div class="card" style="background-color: transparent; padding-bottom: 25px;">
           <div class="card-body" style="background-color: #2B2E32; border-radius: 15px;">
             <h5 class="card-title" style="color: #FFFFFF; font-size: 30px;">Tips For Protesting</h5>
             <div style="background-color: #212529; border-radius: 15px; padding: 15px;">

--- a/src/templates/education.ejs
+++ b/src/templates/education.ejs
@@ -17,7 +17,7 @@
             <div class="card" style="background-color: transparent;">
               <div class="card-body" style="background-color: #2B2E32; border-radius: 15px; height: inherit;">
                 <h5 class="card-title" style="color: #FFFFFF; font-size: 30px;">Reading Materials</h5>
-                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; text-size: 12px;" href="https://www.washingtonpost.com/blogs/post-partisan/wp/2016/01/16/white-privilege-explained/">What Is White Privelige?</a></p>
+                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; text-size: 12px;" href="https://www.washingtonpost.com/blogs/post-partisan/wp/2016/01/16/white-privilege-explained/">What Is White Privilege?</a></p>
 
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.benjerry.com/home/whats-new/2016/systemic-racism-is-real">What Is Systemic Racism?</a>
                   7 ways we know systemic racism is real.</p>
@@ -37,7 +37,7 @@
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.amazon.com/gp/product/1568585985/ref=ox_sc_saved_title_3?smid=ATVPDKIKX0DER&psc=1">Stamped from the Beginning: The Definitive History of
                     Racist Ideas in America:</a>
                   By Ibram X. Kendi</p>
-                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.sentencingproject.org/publications/un-report-on-racial-disparities/">Racial Risparities in the U.S Criminal Justice System"</a>
+                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.sentencingproject.org/publications/un-report-on-racial-disparities/">Racial Disparities in the U.S Criminal Justice System"</a>
                   The United States operates two distinct criminal justice systems: one for wealthy people and another for people of color. </p>
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.urban.org/features/structural-racism-america">Structural Racism In America:</a>
                   This source examines how historical and ongoing public policies, institutional practices, and cultural narratives perpetuate racial inequalities and constrain mobility for communities of color. </p>
@@ -52,7 +52,7 @@
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://drive.google.com/file/d/1gl9JejcGcVW-xBvoLyk1wCH4xbbXYFy6/view">On Being White... And Other Lies:</a>
                   By James Baldwin.</p>
 
-                < </div>
+                </div>
               </div>
             </div>
             <div class="col-lg-4 col-sm-12" style="padding-bottom: 25px;">
@@ -77,9 +77,7 @@
                     </a> Project South is a Southern-based leadership development organization that creates spaces for movement building. They have been working with communities to strengthen leadership and to provide popular political and economic
                     education for personal and social transformation.</p>
                   <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.reclaimtheblock.org/home"> Reclaim the Block:
-                    </a> Reclaim the Block organizes Minneapolis community and city council members to move money from the police department into other areas of the citys budget that truly promote community health and safety.</p>
-                  <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.reclaimtheblock.org/home"> Society for the Study of Social Problems:
-                    </a> he SSSP's stated purpose is to promote and protect sociological research and teaching on significant problems of social life. </p>
+                    </a> Reclaim the Block organizes Minneapolis community and city council members to move money from the police department into other areas of the city's budget that truly promote community health and safety.</p>
                   <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.reclaimtheblock.org/home"> Society for the Study of Social Problems:
                     </a> The SSSP's stated purpose is to promote and protect sociological research and teaching on significant problems of social life. </p>
                   <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://100blackmen.org/"> 100 Black Men:
@@ -88,38 +86,38 @@
               </div>
             </div>
             <div class="col-lg-4 col-sm-12">
-              <div class="card" style="background-color: transparent;" style="padding-bottom: 25px;">
+              <div class="card" style="background-color: transparent; padding-bottom: 25px;">
                 <div class="card-body" style="background-color: #2B2E32; border-radius: 15px; height: inherit;">
                   <h5 class="card-title" style="color: #FFFFFF; font-size: 30px;">Quick Facts</h5>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px;">
                     <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.aclu.org/issues/racial-justice/race-and-economic-justice> Inequality In Education </a></p>
 
-                    <p class="card-text"><span style="color: ##ffcc00;">Black students are suspended and expelled from school three times more often than white students are.</span></p>
+                    <p class="card-text"><span style="color: #ffcc00;">Black students are suspended and expelled from school three times more often than white students are.</span></p>
 
 
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height: inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality /> Race and Economic Inequality</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality > Race and Economic Inequality</a></p>
 
                     <p class="card-text"><span style="color: white;">The median wealth of white households is 20 times that of black households and 18 times that of Latino households.</span></p>
                     <br>
                     <p class="card-text"><span style="color: white;">In the US, Black individuals are twice as likely to be unemployed than white individuals. Once employed, Black individuals earn nearly 25% less than their white counterparts. <a
-                          style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality /> (Economic Policy Institute)</a></span></p>
+                          style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality > (Economic Policy Institute)</a></span></p>
 
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height: inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.ahrq.gov/sites/default/files/wysiwyg/research/findings/nhqrdr/2018qdr-final.pdf. />Healthcare Inequality</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.ahrq.gov/sites/default/files/wysiwyg/research/findings/nhqrdr/2018qdr-final.pdf. >Healthcare Inequality</a></p>
 
                     <p class="card-text"><span style="color: white;"> From 2013 to 2017, white patients in the US received better quality health care than about 34% of Hispanic patients, 40% of Black patients, and 40% of Native American
                         patients (National Healthcare Quality and Disparities Report, 2020)</span></p>
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height: inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.sentencingproject.org/publications/un-report-on-racial-disparities/ /> Criminal Justice Inequality </a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.sentencingproject.org/publications/un-report-on-racial-disparities/ > Criminal Justice Inequality </a></p>
 
-                    <p class="card-text"><span style="color: white;"> African-American adults are 5.9 times as likely to be incarcerated than whitess (US Bureau of Justice Statistics, 2018).</span></p>
+                    <p class="card-text"><span style="color: white;"> African-American adults are 5.9 times as likely to be incarcerated than whites (US Bureau of Justice Statistics, 2018).</span></p>
                     <br>
                     <p class="card-text"><span style="color: white;">
                         <p class="card-text"><span style="color: white;"> Black Americans are more likely than white Americans to be arrested. Once arrested, they are more likely to be convicted, and once convicted, they are more likely to experience
@@ -129,11 +127,11 @@
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height:inherit;">
                     <p class="card-text"><span style="color: white;"> After being fired for misconduct, 450 out of 1,800 officers were able to get their jobs back. </span></p>
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://theweek.com/articles/860002/unjust-power-police-unions />Mathis, Joel (2019, August).</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://theweek.com/articles/860002/unjust-power-police-unions >Mathis, Joel (2019, August).</a></p>
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height:inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://supreme.justia.com/cases/federal/us/457/800/case.html />Qualified Immunity</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://supreme.justia.com/cases/federal/us/457/800/case.html >Qualified Immunity</a></p>
 
                     <p class="card-text"><span style="color: white;"> An officer cannot be held civilly liable for violating a person's rights unless the person's right is established "beyond dispute," and the officer violates a clearly established
                         law that a "reasonable" officer should know. </span></p>
@@ -144,8 +142,8 @@
               </div>
             </div>
           </div>
-
           <%- include('./footer'); -%>
+      </div>
     </body>
 
     </html>

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -16,7 +16,7 @@
       	<% for(var i in data.protests) { %>
       		<% if(i == 'pages')continue; %>
       		<% var country = data.protests[i] %>
-	        <div class="card mb-3" style="background-color: transparent;" style="padding-bottom: 25px;">
+	        <div class="card mb-3" style="background-color: transparent; padding-bottom: 25px;">
 	          <div class="card-body text-center" style="background-color: #2B2E32; border-radius: 15px;">
 	            <h2 class="card-title color-yellow" style="font-size:50px;"><%= country.display_name %></h2>
 	            <h4 class="card-title mb-4">Find your <%= country.pre_region_type %></h4>

--- a/src/templates/petitions.ejs
+++ b/src/templates/petitions.ejs
@@ -121,11 +121,11 @@
           </div>
         </div>
         <div class="col-lg-4 col-sm-12">
-          <div class="card" style="background-color: transparent;" style="padding-bottom: 25px;">
+          <div class="card" style="background-color: transparent; padding-bottom: 25px;">
             <div class="card-body" style="background-color: #2B2E32; border-radius: 15px; height: inherit;">
               <h5 class="card-title" style="color: #FFFFFF; font-size: 30px;">Numbers to Call</h5>
               <div style="background-color: #212529; border-radius: 15px; padding: 15px;">
-                <p class="card-text"><span style="color: ##ffcc00;">Contact:</span></p>
+                <p class="card-text"><span style="color: #ffcc00;">Contact:</span></p>
                 <p class="card-text">Contact each of the below numbers and pressure officials to hold law enforcement accountable for their actions. Information taken from <a style="color: #ffcc00; text-decoration: underline; "
                     href=https://twitter.com/ambivaIcnt> #blacklivesmatter</a></p>
 

--- a/src/templates/safety.ejs
+++ b/src/templates/safety.ejs
@@ -63,7 +63,7 @@
         </div>
       </div>
       <div class="col-lg-4 col-sm-12">
-        <div class="card" style="background-color: transparent;" style="padding-bottom: 25px;">
+        <div class="card" style="background-color: transparent; padding-bottom: 25px;">
           <div class="card-body" style="background-color: #2B2E32; border-radius: 15px;">
             <h5 class="card-title" style="color: #FFFFFF; font-size: 30px;">Tips For Protesting</h5>
             <div style="background-color: #212529; border-radius: 15px; padding: 15px;">

--- a/src/templates/unitedstates/states/education.ejs
+++ b/src/templates/unitedstates/states/education.ejs
@@ -10,14 +10,14 @@
 <body>
 
   <%- include('../../navigation'); -%>
-      <h1 style="padding: 100px; padding-bottom: 50px; font-size: 5vw; color: ##ffcc00; text-align: center;"> Educational Resources <span style="color: white;"></h1>
+      <h1 style="padding: 100px; padding-bottom: 50px; font-size: 5vw; color: #ffcc00; text-align: center;"> Educational Resources <span style="color: white;"></h1>
       <div class="container-fluid">
         <div class="row">
           <div class="col-lg-4 col-sm-12" style="padding-bottom: 25px;">
             <div class="card" style="background-color: transparent;">
               <div class="card-body" style="background-color: #2B2E32; border-radius: 15px; height: inherit;">
                 <h5 class="card-title" style="color: #FFFFFF; font-size: 30px;">Reading Materials</h5>
-                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; text-size: 12px;" href="https://www.washingtonpost.com/blogs/post-partisan/wp/2016/01/16/white-privilege-explained/">What Is White Privelige?</a></p>
+                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; text-size: 12px;" href="https://www.washingtonpost.com/blogs/post-partisan/wp/2016/01/16/white-privilege-explained/">What Is White Privilege?</a></p>
 
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.benjerry.com/home/whats-new/2016/systemic-racism-is-real">What Is Systemic Racism?</a>
                   7 ways we know systemic racism is real.</p>
@@ -37,7 +37,7 @@
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.amazon.com/gp/product/1568585985/ref=ox_sc_saved_title_3?smid=ATVPDKIKX0DER&psc=1">Stamped from the Beginning: The Definitive History of
                     Racist Ideas in America:</a>
                   By Ibram X. Kendi</p>
-                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.sentencingproject.org/publications/un-report-on-racial-disparities/">Racial Risparities in the U.S Criminal Justice System"</a>
+                <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.sentencingproject.org/publications/un-report-on-racial-disparities/">Racial Disparities in the U.S Criminal Justice System"</a>
                   The United States operates two distinct criminal justice systems: one for wealthy people and another for people of color. </p>
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.urban.org/features/structural-racism-america">Structural Racism In America:</a>
                   This source examines how historical and ongoing public policies, institutional practices, and cultural narratives perpetuate racial inequalities and constrain mobility for communities of color. </p>
@@ -52,7 +52,7 @@
                 <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://drive.google.com/file/d/1gl9JejcGcVW-xBvoLyk1wCH4xbbXYFy6/view">On Being White... And Other Lies:</a>
                   By James Baldwin.</p>
 
-                < </div>
+                </div>
               </div>
             </div>
             <div class="col-lg-4 col-sm-12" style="padding-bottom: 25px;">
@@ -77,9 +77,7 @@
                     </a> Project South is a Southern-based leadership development organization that creates spaces for movement building. They have been working with communities to strengthen leadership and to provide popular political and economic
                     education for personal and social transformation.</p>
                   <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.reclaimtheblock.org/home"> Reclaim the Block:
-                    </a> Reclaim the Block organizes Minneapolis community and city council members to move money from the police department into other areas of the citys budget that truly promote community health and safety.</p>
-                  <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.reclaimtheblock.org/home"> Society for the Study of Social Problems:
-                    </a> he SSSP's stated purpose is to promote and protect sociological research and teaching on significant problems of social life. </p>
+                    </a> Reclaim the Block organizes Minneapolis community and city council members to move money from the police department into other areas of the city's budget that truly promote community health and safety.</p>
                   <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://www.reclaimtheblock.org/home"> Society for the Study of Social Problems:
                     </a> The SSSP's stated purpose is to promote and protect sociological research and teaching on significant problems of social life. </p>
                   <p class="card-text"><a style="color: #ffcc00; text-decoration: underline;" href="https://100blackmen.org/"> 100 Black Men:
@@ -88,36 +86,36 @@
               </div>
             </div>
             <div class="col-lg-4 col-sm-12">
-              <div class="card" style="background-color: transparent;" style="padding-bottom: 25px;">
+              <div class="card" style="background-color: transparent; padding-bottom: 25px;">
                 <div class="card-body" style="background-color: #2B2E32; border-radius: 15px; height: inherit;">
                   <h5 class="card-title" style="color: #FFFFFF; font-size: 30px;">Quick Facts</h5>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px;">
                     <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.aclu.org/issues/racial-justice/race-and-economic-justice> Inequality In Education </a></p>
 
-                    <p class="card-text"><span style="color: ##ffcc00;">Black students are suspended and expelled from school three times more often than white students are.</span></p>
+                    <p class="card-text"><span style="color: #ffcc00;">Black students are suspended and expelled from school three times more often than white students are.</span></p>
 
 
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height: inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality /> Race and Econonmic Inequality</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality > Race and Economic Inequality</a></p>
 
                     <p class="card-text"><span style="color: white;">The median wealth of white households is 20 times that of black households and 18 times that of Latino households.</span></p>
                     <br>
                     <p class="card-text"><span style="color: white;">In the US, Black individuals are twice as likely to be unemployed than white individuals. Once employed, Black individuals earn nearly 25% less than their white counterparts. <a
-                          style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality /> (Economic Policy Institute)</a></span></p>
+                          style="color: #ffcc00; text-decoration: underline; " href=https://inequality.org/facts/racial-inequality > (Economic Policy Institute)</a></span></p>
 
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height: inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.ahrq.gov/sites/default/files/wysiwyg/research/findings/nhqrdr/2018qdr-final.pdf. />Healthcare Inequality</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.ahrq.gov/sites/default/files/wysiwyg/research/findings/nhqrdr/2018qdr-final.pdf. >Healthcare Inequality</a></p>
 
                     <p class="card-text"><span style="color: white;"> From 2013 to 2017, white patients in the US received better quality health care than about 34% of Hispanic patients, 40% of Black patients, and 40% of Native American
                         patients (National Healthcare Quality and Disparities Report, 2020)</span></p>
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height: inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.sentencingproject.org/publications/un-report-on-racial-disparities/ /> Criminal Justice Inequality </a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.sentencingproject.org/publications/un-report-on-racial-disparities/ > Criminal Justice Inequality </a></p>
 
                     <p class="card-text"><span style="color: white;"> African-American adults are 5.9 times as likely to be incarcerated than whitess (US Bureau of Justice Statistics, 2018).</span></p>
                     <br>
@@ -129,11 +127,11 @@
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height:inherit;">
                     <p class="card-text"><span style="color: white;"> After being fired for misconduct, 450 out of 1,800 officers were able to get their jobs back. </span></p>
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://theweek.com/articles/860002/unjust-power-police-unions />Mathis, Joel (2019, August).</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://theweek.com/articles/860002/unjust-power-police-unions >Mathis, Joel (2019, August).</a></p>
                   </div>
                   <br>
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height:inherit;">
-                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://supreme.justia.com/cases/federal/us/457/800/case.html />Qualified Immunity</a></p>
+                    <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://supreme.justia.com/cases/federal/us/457/800/case.html >Qualified Immunity</a></p>
 
                     <p class="card-text"><span style="color: white;"> An officer cannot be held civilly liable for violating a person's rights unless the person's right is established "beyond dispute," and the officer violates a clearly established
                         law that a "reasonable" officer should know. </span></p>
@@ -146,6 +144,7 @@
           </div>
 
           <%- include('../../footer'); -%>
+      </div>
     </body>
 
     </html>

--- a/src/templates/unitedstates/states/education.ejs
+++ b/src/templates/unitedstates/states/education.ejs
@@ -117,7 +117,7 @@
                   <div style="background-color: #212529; border-radius: 15px; padding: 15px; height: inherit;">
                     <p class="card-text"><a style="color: #ffcc00; text-decoration: underline; " href=https://www.sentencingproject.org/publications/un-report-on-racial-disparities/ > Criminal Justice Inequality </a></p>
 
-                    <p class="card-text"><span style="color: white;"> African-American adults are 5.9 times as likely to be incarcerated than whitess (US Bureau of Justice Statistics, 2018).</span></p>
+                    <p class="card-text"><span style="color: white;"> African-American adults are 5.9 times as likely to be incarcerated than whites (US Bureau of Justice Statistics, 2018).</span></p>
                     <br>
                     <p class="card-text"><span style="color: white;">
                         <p class="card-text"><span style="color: white;"> Black Americans are more likely than white Americans to be arrested. Once arrested, they are more likely to be convicted, and once convicted, they are more likely to experience


### PR DESCRIPTION
This fixes typos in the Educational Resources page and fixes some html tag errors across pages. Not sure if it was necessary to make changes to `public_NOTUSED` and the `.html` pages but changes were implemented there too.